### PR TITLE
Migrate to App api key for triggering broadcasts

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -488,10 +488,10 @@ describe Customerio::Client do
   end
 
   describe "#trigger_broadcast" do
-    client = Customerio::Client.new("SITE_ID", "API_KEY", :json=>true)
+    client = Customerio::Client.new("SITE_ID", "API_KEY", :json=>true, :app_key=>"APP_KEY")
 
     it "sends a POST request to the customer.io's trigger API" do
-      stub_request(:post, api_uri('/v1/api/campaigns/1/triggers')).
+      stub_request(:post, api_uri('/v1/campaigns/1/triggers')).
           with(:body => {
             :data => { :name => "foo" },
             :recipients => {
@@ -504,7 +504,7 @@ describe Customerio::Client do
     end
 
     it "supports campaign triggers based on email fields" do
-      stub_request(:post, api_uri('/v1/api/campaigns/1/triggers')).
+      stub_request(:post, api_uri('/v1/campaigns/1/triggers')).
           with(:body => {
             :data => { :name => "foo" },
             :emails => ["foo", "bar"],
@@ -521,7 +521,7 @@ describe Customerio::Client do
     end
 
     it "supports campaign triggers based on id fields" do
-      stub_request(:post, api_uri('/v1/api/campaigns/1/triggers')).
+      stub_request(:post, api_uri('/v1/campaigns/1/triggers')).
           with(:body => {
             :data => { :name => "foo" },
             :ids => [1, 2, 3],
@@ -537,7 +537,7 @@ describe Customerio::Client do
 
     it "supports campaign triggers based on per user data" do
       user_data = { :id => 1, :data => { :name => "foo" } }
-      stub_request(:post, api_uri('/v1/api/campaigns/1/triggers')).
+      stub_request(:post, api_uri('/v1/campaigns/1/triggers')).
           with(:body => {
             :data => { :name => "foo" },
             :per_user_data => [user_data]


### PR DESCRIPTION
This PR migrates to the new API keys for triggering broadcasts.

CustomerIO switched to [App API keys](https://customer.io/docs/managing-credentials/#app-api-keys) for https://api.customer.io/v1/api/ , which includes any request to trigger emails.
https://track.customer.io still uses the track API keys for tracking events.

The new api key also uses the `Authorization: "Bearer #{@app_key}"` header instead of the username/password url format. 

